### PR TITLE
Updated link to the Typescript SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ And that was the Jokes MCP Server working in Microsoft Copilot Studio. This is a
 
 ## Jokes MCP Server details
 
-This is a [MCP](https://modelcontextprotocol.io/introduction) server built on the [TypeScript SDK](https://github.com/modelcontextprotocol/csharp-sdk).
+This is a [MCP](https://modelcontextprotocol.io/introduction) server built on the [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk).
 
 With this MCP Server, you will able to fetch jokes from the following websites:
 - [chucknorris.io](https://api.chucknorris.io/)


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file, correcting a link to the TypeScript SDK.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R355): Updated the link to the TypeScript SDK from the incorrect `csharp-sdk` repository to the correct `typescript-sdk` repository.